### PR TITLE
Add filesystem xdg-config/sunshine

### DIFF
--- a/dev.lizardbyte.app.Sunshine.yml
+++ b/dev.lizardbyte.app.Sunshine.yml
@@ -12,6 +12,7 @@ finish-args:
   - --device=all
   - --env=PULSE_PROP_media.category=Manager
   - --filesystem=home
+  - --filesystem=xdg-config/sunshine
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
After updating to 0.22, it uses `~/.var/app/dev.lizardbyte.app.Sunshine/config/sunshine/ `as configuration folder.