### PR TITLE
Allow passing CLI arguments to Sunshine launcher script

### DIFF
--- a/data/dev.lizardbyte.app.Sunshine.sh
+++ b/data/dev.lizardbyte.app.Sunshine.sh
@@ -4,7 +4,7 @@ PORT=47990
 
 if ! curl -k https://localhost:$PORT > /dev/null 2>&1; then
   (sleep 3 && xdg-open https://localhost:$PORT) &
-  sunshine
+  sunshine "$@"
 else
   xdg-open https://localhost:$PORT
 fi


### PR DESCRIPTION
This can be used to customize Sunshine behavior on startup.
