### PR TITLE
fix: allow flatpak spwan exception

### DIFF
--- a/dev.lizardbyte.app.Sunshine.metainfo.xml
+++ b/dev.lizardbyte.app.Sunshine.metainfo.xml
@@ -26,9 +26,6 @@
       /etc/udev/rules.d/60-sunshine-input.rules</p>
     <p>NOTE: Sunshine uses a self-signed certificate. The web browser will report it as not secure,
       but it is safe.</p>
-    <p>NOTE: Allow Sunshine to start apps and games. (Optional)</p>
-    <p>sudo flatpak override
-      --talk-name=org.freedesktop.Flatpak dev.lizardbyte.app.Sunshine</p>
     <p>NOTE: KMS Grab (Optional)</p>
     <p>sudo -i PULSE_SERVER=unix:$(pactl info | awk '/Server String/{print$3}')
       flatpak run dev.lizardbyte.app.Sunshine</p>

--- a/dev.lizardbyte.app.Sunshine.yml
+++ b/dev.lizardbyte.app.Sunshine.yml
@@ -19,7 +19,7 @@ finish-args:
   - --socket=pulseaudio
   - --socket=wayland
   - --system-talk-name=org.freedesktop.Avahi
-  # - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.freedesktop.Flatpak
 
 cleanup:
   - /include


### PR DESCRIPTION
An exception was added to allow Sunshine to start applications in https://github.com/flathub-infra/flatpak-builder-lint/pull/422